### PR TITLE
Updated dependency requirement for xml2js library

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+0.3.4 / 2012-10-04
+===================
+
+  * Fixing a bug in dependencies, xml2js version set to 0.1.14 as newer versions use incompatible versions of coffee-script.
+
 0.3.3 / 2012-04-24
 ==================
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pantry",
 	"description": "A JSON/XML resource caching library based on Request",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"homepage": "https://github.com/Postmedia/pantry",
 	"author": "Edward de Groot <edegroot@postmedia.com> (http://mred9.wordpress.com)",
 	"contributors": [ 
@@ -11,7 +11,7 @@
 	],
 	"dependencies": {
 		"request": ">= 2.1.1",
-		"xml2js": ">= 0.1.10",
+		"xml2js": "0.1.14",
 		"coloured-log": ">=0.9.7"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Discovered during the testing of a timbits project.

The XML2JS lib dependency was updated and recompiled with coffee-script 1.3.3 which utilizes features in node that require a higher node dependency.  As we have made pantry to work with older versions of node this causes exception errors to applications when dependencies are installed.

Change was from an open ended >0.1.10 version to a fixed last known good version of 0.1.14
