### PR TITLE
Correct bug where third party memory store resource date values are not ...

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+0.7.4 / 2014-06016
+==================
+  * Fix for Date comparison in Expired and Spoiled checks when using third party memory storage.
+
 0.7.3 / 2014-05-06
 ===================
   * Bumped request dependecy version

--- a/lib/pantry.js
+++ b/lib/pantry.js
@@ -284,10 +284,10 @@ Pantry.generateKey = function(options) {
 };
 
 Pantry.hasSpoiled = function(resource) {
-  return !(resource.results != null) || (new Date()) > resource.spoilsOn;
+  return !(resource.results != null) || (new Date()) > new Date(resource.spoilsOn);
 };
 
 Pantry.hasExpired = function(resource) {
-  return Pantry.hasSpoiled(resource) || (new Date()) > resource.bestBefore;
+  return Pantry.hasSpoiled(resource) || (new Date()) > new Date(resource.bestBefore);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "pantry",
 	"description": "A JSON/XML resource caching library based on Request",
-	"version": "0.7.3",
+	"version": "0.7.4",
 	"homepage": "https://github.com/Postmedia/pantry",
 	"author": "Edward de Groot <edegroot@postmedia.com> (http://mred9.com)",
 	"contributors": [


### PR DESCRIPTION
...treated as date objects for compare.
