### PR TITLE
Added a Pantry.clear function to manually clear an item

### DIFF
--- a/lib/pantry.js
+++ b/lib/pantry.js
@@ -295,3 +295,24 @@ Pantry.hasExpired = function(resource) {
   return Pantry.hasSpoiled(resource) || (new Date()) > new Date(resource.bestBefore);
 };
 
+Pantry.clear = function(options) {
+  if (typeof options === 'string') {
+    options = {
+      uri: options
+    };
+  }
+
+  if (options.key == null) {
+    options.key = Pantry.generateKey(options);
+  }
+
+  if (Pantry.storage == null) {
+    Pantry.storage = Pantry.backup;
+  }
+
+  Pantry.storage.remove(options.key);
+//  I would like to call Pantry.fetch here to refresh the item, but can't unless the "remove" function
+//  is called with the same callback as fetch, which seems unlikely and redundant, but
+//  there's probably a better way to do it.
+//  Pantry.fetch(options, callback);
+};


### PR DESCRIPTION
Hi guys,

I've used Pantry for a couple of different projects and really like its simplicity.

The only extra thing I needed for my current project was a way to manually clear an item from the cache, so I've added a Pantry.clear() function which simply takes a URL and uses the generateKey function to make a key, then clears it from the cache using the internal Pantry.storage.remove() function.

Though I haven't seen much action in this repo recently, I thought I'd send you a pull request anyway. I hope it's coded how you like it. If not let me know and I'll reformat as required.

Cheers,
Drew Robinson